### PR TITLE
Update maven metadata urls in kotlin-{result,inline-logger}

### DIFF
--- a/resources/libraries/michaelbull-kotlin-inline-logger.json
+++ b/resources/libraries/michaelbull-kotlin-inline-logger.json
@@ -1,7 +1,7 @@
 {
   "name": "michaelbull/kotlin-inline-logger",
   "sourceUrl": "https://github.com/michaelbull/kotlin-inline-logger",
-  "mavenMetaUrl": "https://dl.bintray.com/michaelbull/maven/com/michael-bull/kotlin-inline-logger/kotlin-inline-logger-jvm/maven-metadata.xml",
+  "mavenMetaUrl": "https://repo1.maven.org/maven2/com/michael-bull/kotlin-inline-logger/kotlin-inline-logger/maven-metadata.xml",
   "platform": "JVM",
   "category": "library",
   "tags": [ "generic", "io", "tool", "logger", "logging" ]

--- a/resources/libraries/michaelbull-kotlin-result.json
+++ b/resources/libraries/michaelbull-kotlin-result.json
@@ -1,7 +1,7 @@
 {
   "name": "michaelbull/kotlin-result",
   "sourceUrl": "https://github.com/michaelbull/kotlin-result",
-  "mavenMetaUrl": "https://dl.bintray.com/michaelbull/maven/com/michael-bull/kotlin-result/kotlin-result/maven-metadata.xml",
+  "mavenMetaUrl": "https://repo1.maven.org/maven2/com/michael-bull/kotlin-result/kotlin-result/maven-metadata.xml",
   "platform": "JVM",
   "category": "library",
   "tags": [ "functional", "generic", "result", "either" ]


### PR DESCRIPTION
I've moved publishing of these artifacts from bintray to maven central. This commit updates these references.